### PR TITLE
Add script for local OCR with PaddleOCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Local OCR with PaddleOCR
+
+This repository includes a helper script to run OCR locally using [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR). The model files are fetched automatically and stored in your cache, so an internet connection is required the first time you run the script.
+
+## Setup
+
+1. Install Python 3.8 or later.
+2. Install dependencies:
+   ```bash
+   pip install paddleocr
+   ```
+   Optional: install `huggingface_hub` if you plan to download models via HF APIs.
+
+## Usage
+
+```bash
+python local_ocr.py path/to/image.jpg
+```
+
+The script prints recognized text along with confidence scores and the bounding boxes as `(xmin, ymin)` and `(xmax, ymax)` coordinates.
+
+## Example output
+
+```
+Text: Hello, Score: 0.99, Box: (100, 120), (200, 150)
+```
+
+This demonstrates how each piece of text is returned with its coordinates, allowing you to locate it on the original page.

--- a/local_ocr.py
+++ b/local_ocr.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Run OCR locally using PaddleOCR.
+Requires: pip install paddleocr
+Usage: python local_ocr.py image_path
+Outputs bounding boxes with text.
+"""
+import sys
+from paddleocr import PaddleOCR
+
+if len(sys.argv) < 2:
+    print('Usage: python local_ocr.py image_path')
+    sys.exit(1)
+
+image_path = sys.argv[1]
+ocr = PaddleOCR(use_angle_cls=True, lang='en')
+
+result = ocr.ocr(image_path, cls=True)
+
+for line in result:
+    for box, (text, score) in line:
+        # box is [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]
+        xs = [int(b[0]) for b in box]
+        ys = [int(b[1]) for b in box]
+        xmin, xmax = min(xs), max(xs)
+        ymin, ymax = min(ys), max(ys)
+        print(f'Text: {text}, Score: {score:.2f}, Box: ({xmin}, {ymin}), ({xmax}, {ymax})')


### PR DESCRIPTION
## Summary
- add README with instructions on using PaddleOCR
- add `local_ocr.py` script for text extraction with bounding boxes

## Testing
- `python local_ocr.py` (shows usage message)

------
https://chatgpt.com/codex/tasks/task_b_6862c546acc08330ab3e0d7f8017090e