### PR TITLE
Add Tkinter file selector for PaddleOCR script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Local OCR with PaddleOCR
+
+This repository includes a helper script to run OCR locally using [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR). The model files are fetched automatically and stored in your cache, so an internet connection is required the first time you run the script.
+
+## Setup
+
+1. Install Python 3.8 or later.
+2. Install dependencies:
+   ```bash
+   pip install paddleocr
+   ```
+   Optional: install `huggingface_hub` if you plan to download models via HF APIs.
+
+## Usage
+
+```bash
+python local_ocr.py [path/to/image.jpg]
+```
+
+If no path is provided, the script opens a Tkinter file dialog so you can choose an image. The recognized text is printed with confidence scores and the bounding boxes as `(xmin, ymin)` and `(xmax, ymax)` coordinates.
+
+## Example output
+
+```
+Text: Hello, Score: 0.99, Box: (100, 120), (200, 150)
+```
+
+This demonstrates how each piece of text is returned with its coordinates, allowing you to locate it on the original page.

--- a/local_ocr.py
+++ b/local_ocr.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Run OCR locally using PaddleOCR.
+Requires: pip install paddleocr
+Usage: python local_ocr.py [image_path]
+Outputs bounding boxes with text. If no path is given, a file dialog will open
+to choose an image.
+"""
+import sys
+import tkinter as tk
+from tkinter import filedialog
+from paddleocr import PaddleOCR
+
+if len(sys.argv) >= 2:
+    image_path = sys.argv[1]
+else:
+    root = tk.Tk()
+    root.withdraw()
+    image_path = filedialog.askopenfilename(
+        title="Select image file",
+        filetypes=[
+            ("Image Files", "*.jpg *.jpeg *.png *.bmp *.tiff"),
+            ("All Files", "*.*"),
+        ],
+    )
+    if not image_path:
+        print("No file selected. Exiting.")
+        sys.exit(0)
+ocr = PaddleOCR(use_angle_cls=True, lang='en')
+
+result = ocr.ocr(image_path, cls=True)
+
+for line in result:
+    for box, (text, score) in line:
+        # box is [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]
+        xs = [int(b[0]) for b in box]
+        ys = [int(b[1]) for b in box]
+        xmin, xmax = min(xs), max(xs)
+        ymin, ymax = min(ys), max(ys)
+        print(f'Text: {text}, Score: {score:.2f}, Box: ({xmin}, {ymin}), ({xmax}, {ymax})')


### PR DESCRIPTION
## Summary
- extend `local_ocr.py` to open a Tkinter file dialog when no image path is given
- update README usage instructions for optional path and GUI selection

## Testing
- `python local_ocr.py` *(fails: ModuleNotFoundError: No module named 'paddleocr')*
- `python local_ocr.py dummy.jpg` *(fails: ModuleNotFoundError: No module named 'paddleocr')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6862c546acc08330ab3e0d7f8017090e